### PR TITLE
Add a clarification about Fliplr/Flipud

### DIFF
--- a/source/augmenters.rst
+++ b/source/augmenters.rst
@@ -324,6 +324,10 @@ Flip/mirror input images horizontally.
 Flip 50% of all images horizontally::
 
     aug = iaa.Fliplr(0.5)
+    
+NOTE: the default probability is 0, so to flip all images, do::
+
+    aug = iaa.Fliplr(1)
 
 .. figure:: ../images/overview_of_augmenters/fliplr.jpg
     :alt: Horizontal flip
@@ -336,6 +340,10 @@ Flip/mirror input images vertically.
 Flip 50% of all images vertically::
 
     aug = iaa.Flipud(0.5)
+    
+NOTE: the default probability is 0, so to flip all images, do::
+
+    aug = iaa.Flipud(1)
 
 .. figure:: ../images/overview_of_augmenters/flipud.jpg
     :alt: Vertical flip


### PR DESCRIPTION
The default probability for Fliplr/Flipud is 0. I wasn't expecting that, and it bit me pretty hard, so I've added a clarification to the docs.

I've double-checked that this is the case for both Fliplr and Flipud. I've also checked in the source to make sure that an input probability of 1 will work (either 1 or 1.0 will work fine).